### PR TITLE
Remove unnecessary null-aware operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.2
+
+- Remove unnecessary null-aware operators
+
 ## 0.0.1
 
 - Initial release.

--- a/lib/cross_file_image.dart
+++ b/lib/cross_file_image.dart
@@ -45,7 +45,7 @@ class XFileImage extends ImageProvider<XFileImage> {
 
     if (bytes.lengthInBytes == 0) {
       // The file may become available later.
-      PaintingBinding.instance!.imageCache!.evict(key);
+      PaintingBinding.instance.imageCache.evict(key);
       throw StateError('$file is empty and cannot be loaded as an image.');
     }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cross_file_image
 description: ImageProvider for XFile.
-version: 0.0.1
+version: 0.0.2
 homepage: https://github.com/qiuxiang/cross_file_image
 
 environment:


### PR DESCRIPTION
我打`flutter build appbundle`的时候，遇到了这样的问题。
![image](https://user-images.githubusercontent.com/53505355/168225590-e74ee523-ddcc-428d-8258-81053907c67d.png)

```
../../Library/flutter/.pub-cache/hosted/pub.dartlang.org/cross_file_image-0.0.1/lib/cross_file_image.dart:48:23: Warning: Operand of null-aware operation '!' has type 'PaintingBinding' which excludes null.
 - 'PaintingBinding' is from 'package:flutter/src/painting/binding.dart' ('../../Library/flutter/packages/flutter/lib/src/painting/binding.dart').
      PaintingBinding.instance!.imageCache!.evict(key);
                      ^
../../Library/flutter/.pub-cache/hosted/pub.dartlang.org/cross_file_image-0.0.1/lib/cross_file_image.dart:48:33: Warning: Operand of null-aware operation '!' has type 'ImageCache' which excludes null.
 - 'ImageCache' is from 'package:flutter/src/painting/image_cache.dart' ('../../Library/flutter/packages/flutter/lib/src/painting/image_cache.dart').
      PaintingBinding.instance!.imageCache!.evict(key);
                                ^
```